### PR TITLE
Live, borderreflection, crop subfolders, name & acc display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+model.pt 
+/objects/
+/train/
+/val/
+/__pycache__/

--- a/crop.py
+++ b/crop.py
@@ -43,16 +43,16 @@ def crop(args):
                         row = next(csvreader)
                         x, y, w, h = map(int, row)
 
-                        top_bottom_border = int((h * float(args.border)) / 2)
-                        left_right_border = int((w * float(args.border)) / 2)
-
-                        
-                    
                     frame = cv.imread(image_path)
+                    height, width = frame.shape[:2]
+
+                    # Create BORDER_REFLECT using the original shape of the frame
+                    top_bottom_border = int((height * float(args.border)) / 2)
+                    left_right_border = int((width * float(args.border)) / 2)
+                    
                     frame = cv.copyMakeBorder(
                         frame, top_bottom_border, top_bottom_border, left_right_border, left_right_border, cv.BORDER_REFLECT
                         )
-                    
     #   Crop the face with border added and save it to either the TRAIN_FOLDER or VAL_FOLDER
     #   You can use 
     #
@@ -60,14 +60,17 @@ def crop(args):
     #
     #   to decide how to split them.
 
-                    # adjust original coordinates according to the BORDER_REFLECT
+                    # Adjust original coordinates according to the BORDER_REFLECT
+                    # Create the border by widening cropping-area using the width and height of the found face
+                    top_bottom_border_crop = int((h * float(args.border)) / 2)
+                    left_right_border_crop = int((w * float(args.border)) / 2)
                     x = x + left_right_border
                     y = y + top_bottom_border
 
-                    left = x - left_right_border
-                    right = x + w + left_right_border
-                    top = y - top_bottom_border
-                    bottom = y + h + top_bottom_border
+                    left = x - left_right_border_crop
+                    right = x + w + left_right_border_crop
+                    top = y - top_bottom_border_crop
+                    bottom = y + h + top_bottom_border_crop
 
                     cropped_frame = frame[top:bottom, left:right]
 

--- a/crop.py
+++ b/crop.py
@@ -72,11 +72,15 @@ def crop(args):
                     cropped_frame = frame[top:bottom, left:right]
 
                     if random.uniform(0.0, 1.0) < float(args.split):
-                        file_path = os.path.join(VAL_FOLDER, image_file_name)
+                        subfolder_path = os.path.join(VAL_FOLDER, folder)
+                        os.makedirs(subfolder_path, exist_ok=True)
+                        file_path = os.path.join(subfolder_path, image_file_name)
                         cv.imwrite(file_path, cropped_frame)
                     
                     else:
-                        file_path = os.path.join(TRAIN_FOLDER, image_file_name)
+                        subfolder_path = os.path.join(TRAIN_FOLDER, folder)
+                        os.makedirs(subfolder_path, exist_ok=True)
+                        file_path = os.path.join(subfolder_path, image_file_name)
                         cv.imwrite(file_path, cropped_frame)
 
 

--- a/live.py
+++ b/live.py
@@ -5,9 +5,8 @@ from network import Net
 #from cascade import create_cascade
 from transforms import ValidationTransform
 from PIL import Image
-
 import gdown
-import random
+
 
 # NOTE: This will be the live execution of your pipeline
 

--- a/live.py
+++ b/live.py
@@ -1,22 +1,77 @@
 import cv2 as cv
 import torch
 import os
-from network import Net
-from cascade import create_cascade
+#from network import Net
+#from cascade import create_cascade
 from transforms import ValidationTransform
 from PIL import Image
+
+import gdown
 
 # NOTE: This will be the live execution of your pipeline
 
 def live(args):
     # TODO: 
     #   Load the model checkpoint from a previous training session (check code in train.py)
+        ## TODO
+
+
+
+    '''
     #   Initialize the face recognition cascade again (reuse code if possible)
+    if os.path.exists(cv.data.haarcascades + "haarcascade_frontalface_default.xml"):
+        HAAR_CASCADE = cv.data.haarcascades + "haarcascade_frontalface_default.xml"
+    else:
+        print("No HAAR_CASCADE-file found. Downloading it from Google Drive.")
+        url = "PERSONAL_LINK_TO_GOOGLE_DRIVE"
+        output = "haarcascade_frontalface_default.xml"
+        gdown.download(url, output, fuzzy=True)
+        HAAR_CASCADE = output
+
+    face_cascade = cv.CascadeClassifier(HAAR_CASCADE)
+    '''
+
     #   Also, create a video capture device to retrieve live footage from the webcam.
+    cap = cv.VideoCapture(0)
+    if not cap.isOpened():
+        print("Cannot open camera")
+        exit()
+
     #   Attach border to the whole video frame for later cropping.
     #   Run the cascade on each image, crop all faces with border.
     #   Run each cropped face through the network to get a class prediction.
     #   Retrieve the predicted persons name from the checkpoint and display it in the image
+
+    while True:
+        # Capture frame-by-frame
+        ret, frame = cap.read()
+
+        h, w = frame.shape[:2]
+        top_bottom_border = int((h * float(args.border)) / 2)
+        left_right_border = int((w * float(args.border)) / 2)
+        
+        frame_border = cv.copyMakeBorder(
+                            frame, top_bottom_border, top_bottom_border, left_right_border, left_right_border, cv.BORDER_REFLECT
+                        )
+
+
+
+        '''
+        gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
+        faces = face_cascade.detectMultiScale(gray, 1.3, 5)
+
+        frame_rectangle = frame.copy()
+
+        for (x,y,w,h) in faces:
+            frame_rectangle = cv.rectangle(frame_rectangle,(x,y),(x+w,y+h),(255,0,0),2)
+        '''
+        cv.imshow('webcam',frame_border)
+        if cv.waitKey(1) == ord('q'):
+            break
+
+
+
+
     if args.border is None:
         print("Live mode requires a border value to be set")
         exit()

--- a/live.py
+++ b/live.py
@@ -1,23 +1,24 @@
 import cv2 as cv
 import torch
 import os
-#from network import Net
+from network import Net
 #from cascade import create_cascade
 from transforms import ValidationTransform
 from PIL import Image
 
 import gdown
+import random
 
 # NOTE: This will be the live execution of your pipeline
 
 def live(args):
     # TODO: 
     #   Load the model checkpoint from a previous training session (check code in train.py)
-        ## TODO
+    checkpoint = torch.load("model.pt")
+    model = Net(nClasses=len(checkpoint['classes']))
+    model.load_state_dict(checkpoint['model'])
+    classes = checkpoint['classes']
 
-
-
-    '''
     #   Initialize the face recognition cascade again (reuse code if possible)
     if os.path.exists(cv.data.haarcascades + "haarcascade_frontalface_default.xml"):
         HAAR_CASCADE = cv.data.haarcascades + "haarcascade_frontalface_default.xml"
@@ -29,7 +30,6 @@ def live(args):
         HAAR_CASCADE = output
 
     face_cascade = cv.CascadeClassifier(HAAR_CASCADE)
-    '''
 
     #   Also, create a video capture device to retrieve live footage from the webcam.
     cap = cv.VideoCapture(0)
@@ -46,31 +46,59 @@ def live(args):
         # Capture frame-by-frame
         ret, frame = cap.read()
 
-        h, w = frame.shape[:2]
-        top_bottom_border = int((h * float(args.border)) / 2)
-        left_right_border = int((w * float(args.border)) / 2)
+        height, width = frame.shape[:2]
+        top_bottom_border = int((height * float(args.border)) / 2)
+        left_right_border = int((width * float(args.border)) / 2)
         
         frame_border = cv.copyMakeBorder(
                             frame, top_bottom_border, top_bottom_border, left_right_border, left_right_border, cv.BORDER_REFLECT
                         )
 
-
-
-        '''
-        gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
+        gray = cv.cvtColor(frame_border, cv.COLOR_BGR2GRAY)
         faces = face_cascade.detectMultiScale(gray, 1.3, 5)
 
-        frame_rectangle = frame.copy()
+        frame_rectangle = frame_border.copy()
 
         for (x,y,w,h) in faces:
-            frame_rectangle = cv.rectangle(frame_rectangle,(x,y),(x+w,y+h),(255,0,0),2)
-        '''
-        cv.imshow('webcam',frame_border)
+            # Show blue border like at record.py
+            top_bottom_border = int((h * float(args.border)) / 2)
+            left_right_border = int((w * float(args.border)) / 2)
+
+            left = max(x - left_right_border, 0)
+            right = min(x + w + left_right_border, frame_border.shape[1])
+            top = max(y - top_bottom_border, 0)
+            bottom = min(y + h + top_bottom_border, frame_border.shape[0])
+
+            if top >= bottom or left >= right:
+                print("Ungültige Rahmenkoordinaten:", top, bottom, left, right)
+                continue
+
+            frame_rectangle = cv.rectangle(frame_rectangle,(left, top),(right, bottom),(255,0,0),2)
+            cropped_face = frame_border[top:bottom, left:right]
+
+            if cropped_face.size == 0:
+                print("Leeres Gesichtsfeld bei:", top, bottom, left, right)
+                continue
+
+            # Convert frame to image
+            frame_image = Image.fromarray(cv.cvtColor(cropped_face, cv.COLOR_BGR2RGB))
+
+            # Transform to tensor
+            transformed_image = ValidationTransform(frame_image)
+
+            # Classify tensor using the pre-trained model
+            with torch.no_grad():
+                model.eval()
+                output = model(transformed_image.unsqueeze(0))
+            predicted_class = torch.argmax(output, dim=1).item()
+            class_name = classes[predicted_class]
+    
+            cv.putText(frame_rectangle, class_name, (x-left_right_border, y-top_bottom_border - 10), cv.FONT_HERSHEY_SIMPLEX, 0.9, (255, 0, 0), 2)
+            
+
+        cv.imshow('webcam',frame_rectangle)
         if cv.waitKey(1) == ord('q'):
             break
-
-
-
 
     if args.border is None:
         print("Live mode requires a border value to be set")

--- a/network.py
+++ b/network.py
@@ -52,7 +52,3 @@ class Net(nn.Module):
         x = self.fc2(x)
         
         return x
-
-# TEST OUTPUT
-model = Net(nClasses=10)
-print(model)

--- a/train.py
+++ b/train.py
@@ -27,8 +27,8 @@ def train(args):
     nClasses = len(trainset.classes)
 
     # Create data loader
-    trainloader = DataLoader(trainset, batch_size=BATCH_SIZE, shuffle=True)
-    validationloader = DataLoader(validationset, batch_size=BATCH_SIZE, shuffle=True)
+    trainloader = DataLoader(trainset, batch_size=BATCH_SIZE, shuffle=True, drop_last=True)
+    validationloader = DataLoader(validationset, batch_size=BATCH_SIZE, shuffle=True, drop_last=True)
 
     # Create the network, the optimizer and the loss function
     net = Net(nClasses)


### PR DESCRIPTION
I implemented the live.py as specified in the task description.
Moreover I corrected several issues:

- To train the model correctly the torchvision.datasets.ImageFolder() needs to find sub-folders in the corresponding folders (train, val) with the classnames.
- The borderreflection (crop.py) was not implemented correct. At an earlier state the border of a frame was calculated by using the width and height (w, h) from the cascade. Afterwards, the same amount of border that was added to the image-frame was also added to the face crop. Now the frame gets an borderreflection using the original shape of the image-frame and the face cropping-area border is calculated by the w, h from the cascade.
- In this context the coordinate- and border-calculations in the live.py were adjusted.
- I enhaced the display of the name-prediction and added an accuracy indicator.
- I added the following to the .gitignore: 
model.pt, /objects/, /train/, /val/, /__pycache__/